### PR TITLE
Reset tf.keras Session in Setup

### DIFF
--- a/mltest/mltest.py
+++ b/mltest/mltest.py
@@ -26,7 +26,7 @@ class InfTensorException(Exception):
     pass
 
 
-def setup(tf_seed=0, np_seed=0, python_seed=0, reset_graph=True):
+def setup(tf_seed=0, np_seed=0, python_seed=0, reset_graph=True, set_keras_session=True):
     """Automatically setup standard testing configuration.
     Resets tensorflow's default graph and sets various seeds.
     Args:
@@ -43,6 +43,9 @@ def setup(tf_seed=0, np_seed=0, python_seed=0, reset_graph=True):
         np.random.seed(np_seed)
     if python_seed is not None:
         random.seed(python_seed)
+    if set_keras_session:
+      sess = tf.Session(graph=tf.get_default_graph())
+      tf.keras.backend.set_session(sess)
 
 
 def _initalizer_helper(sess_conf, init_op):


### PR DESCRIPTION
tf.keras is becoming the [standard](https://www.tensorflow.org/alpha/guide/keras/overview) in Tensorflow. In order to get reproducible results with keras, howerver, the tf.keras session must be reset after all random number generators are seeded

Details are described [here](https://keras.io/getting-started/faq/#how-can-i-obtain-reproducible-results-using-keras-during-development) in the Keras FAQ.

